### PR TITLE
ws fixes

### DIFF
--- a/src/main/java/com/sameerasw/ticketin/handler/TicketCountWebSocketHandler.java
+++ b/src/main/java/com/sameerasw/ticketin/handler/TicketCountWebSocketHandler.java
@@ -41,6 +41,9 @@ public class TicketCountWebSocketHandler extends TextWebSocketHandler {
     }
 
     private void sendCurrentTicketCount(WebSocketSession session, Long eventId) {
+        if (!session.isOpen()) {
+            return;
+        }
         int availableTickets = 0;
         var ticketPool = ticketPoolService.getTicketPoolByEventItemId(eventId);
         if (ticketPool != null) {


### PR DESCRIPTION
This pull request includes a change to the `TicketCountWebSocketHandler` class to improve the stability of the WebSocket connection handling. The most important change is the addition of a check to ensure the WebSocket session is open before attempting to send the current ticket count.

Stability Improvement:

* [`src/main/java/com/sameerasw/ticketin/handler/TicketCountWebSocketHandler.java`](diffhunk://#diff-811545c185269f69823b927d6be3792e41eb4701899bdb10a1428c60731daa6aR44-R46): Added a condition to check if the WebSocket session is open before proceeding with the `sendCurrentTicketCount` method to prevent errors when the session is closed.